### PR TITLE
c++14 for PCL compat

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,8 +3,6 @@ project(libobjecttracker)
 
 find_package(catkin)
 
-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
-
 ###################################
 ## catkin specific configuration ##
 ###################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,9 +3,7 @@ project(libobjecttracker)
 
 find_package(catkin)
 
-# Enable C++11
-# This requires PCL to be compiled with C++11 enabled as well!
-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
 
 ###################################
 ## catkin specific configuration ##

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,9 @@ project(libobjecttracker)
 
 find_package(catkin)
 
+set (CMAKE_CXX_STANDARD 11)
+set (CMAKE_CXX_STANDARD_REQUIRED ON)
+
 ###################################
 ## catkin specific configuration ##
 ###################################

--- a/src/object_tracker.cpp
+++ b/src/object_tracker.cpp
@@ -7,6 +7,7 @@
 #include <pcl/registration/icp.h>
 #include <pcl/registration/transformation_estimation_2D.h>
 // #include <pcl/registration/transformation_estimation_lm.h>
+#include <pcl/search/impl/search.hpp>
 
 #include "assignment.hpp"
 

--- a/src/profile.cpp
+++ b/src/profile.cpp
@@ -12,6 +12,7 @@
 #include <pcl/point_types.h>
 #include <pcl/common/transforms.h>
 #include <pcl/registration/icp.h>
+#include <pcl/search/impl/search.hpp>
 
 #ifdef USE_VICON_DIRECTLY
 // VICON


### PR DESCRIPTION
Trying to get the Ubuntu 20 compile working for Python 3 support in Crazyswarm. The default version of apt package `libpcl-dev` on Ubuntu 20 requires C++14. After making this change, I was able to get Crazyswarm to compile simultaneously on Ubuntu 16, 18, and 20. However, I am not sure if there will be ABI issues on Ubuntu 16/18 where `libpcl-dev` is compiled with `-std=c++11`. I will test to be certain.

Creating this PR for discussion in case there is anything else to consider. Will also need the same change in `libmotioncapture`.